### PR TITLE
使用 PureJSON 以确保不会出现转义问题

### DIFF
--- a/wrapper_func.go
+++ b/wrapper_func.go
@@ -38,10 +38,10 @@ func W(fn func(ctx *Context) (Result, error)) gin.HandlerFunc {
 		}
 		if err != nil {
 			slog.Error("执行业务逻辑失败", slog.Any("err", err))
-			ctx.JSON(http.StatusInternalServerError, res)
+			ctx.PureJSON(http.StatusInternalServerError, res)
 			return
 		}
-		ctx.JSON(http.StatusOK, res)
+		ctx.PureJSON(http.StatusOK, res)
 	}
 }
 
@@ -64,10 +64,10 @@ func B[Req any](fn func(ctx *Context, req Req) (Result, error)) gin.HandlerFunc 
 		}
 		if err != nil {
 			slog.Error("执行业务逻辑失败", slog.Any("err", err))
-			ctx.JSON(http.StatusInternalServerError, res)
+			ctx.PureJSON(http.StatusInternalServerError, res)
 			return
 		}
-		ctx.JSON(http.StatusOK, res)
+		ctx.PureJSON(http.StatusOK, res)
 	}
 }
 
@@ -100,10 +100,10 @@ func BS[Req any](fn func(ctx *Context, req Req, sess session.Session) (Result, e
 		}
 		if err != nil {
 			slog.Error("执行业务逻辑失败", slog.Any("err", err))
-			ctx.JSON(http.StatusInternalServerError, res)
+			ctx.PureJSON(http.StatusInternalServerError, res)
 			return
 		}
-		ctx.JSON(http.StatusOK, res)
+		ctx.PureJSON(http.StatusOK, res)
 	}
 }
 
@@ -130,9 +130,9 @@ func S(fn func(ctx *Context, sess session.Session) (Result, error)) gin.HandlerF
 		}
 		if err != nil {
 			slog.Error("执行业务逻辑失败", slog.Any("err", err))
-			ctx.JSON(http.StatusInternalServerError, res)
+			ctx.PureJSON(http.StatusInternalServerError, res)
 			return
 		}
-		ctx.JSON(http.StatusOK, res)
+		ctx.PureJSON(http.StatusOK, res)
 	}
 }


### PR DESCRIPTION
在 Go 默认的 JSON 序列化中，如果是 <, > 之类的标签会被转化为 unicode 编码，也就是 \uxxxx 这种形态。在这种情况下，前端如果要渲染一些富文本，那么就会出现问题。

因此我们在这里改用 PureJSON，其底层实现设置不转移。