### PR TITLE
修复Redis限流器同一时间多个请求只计算一次的问题

### DIFF
--- a/internal/ratelimit/redis_slide_window.go
+++ b/internal/ratelimit/redis_slide_window.go
@@ -17,8 +17,10 @@ package ratelimit
 import (
 	"context"
 	_ "embed"
+	"fmt"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/redis/go-redis/v9"
 )
 
@@ -38,6 +40,10 @@ type RedisSlidingWindowLimiter struct {
 }
 
 func (r *RedisSlidingWindowLimiter) Limit(ctx context.Context, key string) (bool, error) {
+	uid, err := uuid.NewUUID()
+	if err != nil {
+		return false, fmt.Errorf("generate uuid failed: %w", err)
+	}
 	return r.Cmd.Eval(ctx, luaSlideWindow, []string{key},
-		r.Interval.Milliseconds(), r.Rate, time.Now().UnixMilli()).Bool()
+		r.Interval.Milliseconds(), r.Rate, time.Now().UnixMilli(), uid.String()).Bool()
 }

--- a/internal/ratelimit/slide_window.lua
+++ b/internal/ratelimit/slide_window.lua
@@ -5,6 +5,9 @@ local window = tonumber(ARGV[1])
 -- 阈值
 local threshold = tonumber(ARGV[2])
 local now = tonumber(ARGV[3])
+-- 唯一ID, 用于解决同一时间内多个请求只统计一次的问题
+-- SEE: issue #27
+local uid = ARGV[4]
 -- 窗口的起始时间
 local min = now - window
 
@@ -15,8 +18,8 @@ if cnt >= threshold then
     -- 执行限流
     return "true"
 else
-    -- 把 score 和 member 都设置成 now
-    redis.call('ZADD', key, now, now)
+    -- score 设置为当前时间, member 设置为唯一id
+    redis.call('ZADD', key, now, uid)
     redis.call('PEXPIRE', key, window)
     return "false"
 end


### PR DESCRIPTION
为每个请求新增了uuid, 这样同一时间进来的多个请求也会被独立计算。
<img width="449" alt="7a9b94cad785d0a454f54f39c8deeba" src="https://github.com/user-attachments/assets/75cbacf5-f488-4c8a-89cf-e6e48b7e9e1b">

- fixed #27 